### PR TITLE
Cordova iOS 4 compatibility

### DIFF
--- a/lib/profiles.coffee
+++ b/lib/profiles.coffee
@@ -87,7 +87,10 @@ module.exports = (config) ->
         ]
   # iOS (Retina and legacy resolutions)
   'ios':
-    dir: path.join 'platforms', 'ios', config.prjName, 'Resources', 'splash'
+    dir: if config.useXCAssetsPath
+      path.join 'platforms', 'ios', config.prjName, 'Images.xcassets', 'LaunchImage.launchimage'
+    else
+      path.join 'platforms', 'ios', config.prjName, 'Resources', 'splash'
     layout:
       landscape:
         splashs: [

--- a/tasks/phonegapsplash.coffee
+++ b/tasks/phonegapsplash.coffee
@@ -33,7 +33,8 @@ module.exports = (grunt) ->
       layouts: [ 'portrait', 'landscape', 'none' ]
       profiles: [
         'android', 'bada', 'blackberry', 'ios', 'webos', 'windows-phone'
-      ]
+      ],
+      useXCAssetsPath: false
     # Get all profiles as constants
     PROFILES = (require '../lib/profiles') options
     # Check existence of source file


### PR DESCRIPTION
Add `useXCAssetsPath` option. Set to true to write files to the default path used in Cordova iOS 4. 

Example usage:

```
grunt.initConfig({
    phonegapsplash: {
        your_target: {
            src: './raw/splash.svg',
            dest: './',
            options: {
                prjName: 'Example Project',
                profiles: ['ios'],
                useXCAssetsPath: true
            }
        }
    }
});
```
